### PR TITLE
Swap "us" and "en" for Linux in GetRegionString

### DIFF
--- a/shared/linux/LinuxUtils.cpp
+++ b/shared/linux/LinuxUtils.cpp
@@ -289,7 +289,7 @@ void RemoveFile( string fileName, bool bAddSavePath)
 
 string GetRegionString()
 {
-	return "us_en";
+	return "en_us";
 }
 
 //month is 1-12 btw


### PR DESCRIPTION
There's no such country whose two letter code is "en", maybe meant to say "en_US"?