### PR TITLE
fix RT_RUNS_IN_BACKGROUND flag.

### DIFF
--- a/shared/win/app/main.cpp
+++ b/shared/win/app/main.cpp
@@ -553,9 +553,9 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 			{
 				GetBaseApp()->OnEnterBackground();
 			}
+			g_bHasFocus = false;
 		}
 
-		g_bHasFocus = false;
 		LogMsg("App lost focus");
 		break;
 


### PR DESCRIPTION
in main.cpp "g_bHasFocus" was misplaced which caused RT_RUNS_IN_BACKGROUND to misbehave.