### PR TITLE
OPTIMIZATION: Reduce CPU usage by ~6%

### DIFF
--- a/shared/win/app/main.cpp
+++ b/shared/win/app/main.cpp
@@ -1911,6 +1911,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, TCHAR *lpCmdLin
 
 		if (g_fpsLimit != 0)
 		{
+			Sleep(1);
 			while (fpsTimer > GetSystemTimeAccurate())
 			{
 				Sleep(0);


### PR DESCRIPTION
This fixes that the CPU is put on full constraint, even with an FPS cap active. It happens because the accurate "sleeping" happens with the Sleep(0) (this doesn't actually sleep, at best it tells the cpu scheduler on the OS to reschedule execution for other threads, kind of like yielding) in the fpsTimer while loop.

But there should also be an inaccurate proper sleep to avoid maxing out one core, 1ms is good.

The new FPS cap remains very accurate at a stable 60 FPS (tested). Capping beyond 1000 FPS may cause inaccuracies but eh, who would ever do that?