### PR TITLE
Fix crash upon startup on Android

### DIFF
--- a/shared/android/AndroidUtils.cpp
+++ b/shared/android/AndroidUtils.cpp
@@ -137,7 +137,7 @@ char * GetAndroidMainClassName()
 	if (bFirstTime)
 	{
 		bFirstTime = false;
-		string package = string(GetBundlePrefix()) + string("RTAndroidApp") + "/Main";
+		string package = "com.rtsoft.RTAndroidApp/Main";
 
 		//string package = string(GetBundlePrefix())+string(GetBundleName())+"/Main";
 		StringReplace(".", "/", package);


### PR DESCRIPTION
With the new compiling system on Android `GetAndroidMainClassName()` should always return `com.rtsoft.RTAndroidApp/Main`.
This will also probably fix #17.