### PR TITLE
Fix potentially inserting out of bounds iterator. [RTPack]

### DIFF
--- a/RTPack/source/FontPacker.cpp
+++ b/RTPack/source/FontPacker.cpp
@@ -185,7 +185,9 @@ bool FontPacker::WriteHeaderBitMapFontGeneratorXML(FILE *fp, string fntFile, rtf
 			}
 			++insIt;
 		}
-		charList.insert(insIt, c);
+		
+		if (insIt != charList.end())
+			charList.insert(insIt, c);
 	}
 
 	header.firstChar = charList.front().id;


### PR DESCRIPTION
Missing check before inserting iterator to charList could cause the end/oob iterator to be inserted to the list - as the iterator gets advanced one last time within the loop, leading to undefined behavior when the insert occurs in outer scope.