### PR TITLE
Font::WriteHeaderBitMapFontGenerator fix pushing invalid iterator UB

### DIFF
--- a/RTPack/source/FontPacker.cpp
+++ b/RTPack/source/FontPacker.cpp
@@ -69,7 +69,8 @@ bool FontPacker::WriteHeaderBitMapFontGenerator(FILE *fp, string fntFile, rtfont
 			}
 			++insIt;
 		}
-		charList.insert(insIt, c);
+		if (insIt != charList.end())
+			charList.insert(insIt, c);
 	}
 
 	header.firstChar = charList.front().id;


### PR DESCRIPTION
Same fix as in https://github.com/SethRobinson/proton/pull/25
Should have probably been fixed before already as well but I oddly just started getting issues with this, so fixed it now.