### PR TITLE
RTPack: Fix compilation issue on MacOS

### DIFF
--- a/RTPack/linux/CMakeLists.txt
+++ b/RTPack/linux/CMakeLists.txt
@@ -11,8 +11,10 @@ set(RASPBERRYPI_GLES11 OFF)
 
 ENABLE_LANGUAGE(C)
 
-include(CheckIncludeFile)
-CHECK_INCLUDE_FILE(/opt/vc/include/bcm_host.h ISRASPBERRYPIE)
+if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  include(CheckIncludeFile)
+  CHECK_INCLUDE_FILE(/opt/vc/include/bcm_host.h ISRASPBERRYPIE)
+endif()
 
 #if(ISRASPBERRYPIE)
 OPTION(RASPBERRYPI_GLES11 "Compile for Raspberry PI GLES" ON)
@@ -22,6 +24,7 @@ OPTION(RASPBERRYPI_GLES11 "Compile for Raspberry PI GLES" ON)
 
 project (RTPack)
 include(../../shared/linux/Proton.cmake)
+
 # additional compiler flags -DSIMPLE_PROFILING_ACTIVE
 add_definitions(-D_CONSOLE -DRTLINUX -DRT_NO_PVR)
 
@@ -35,13 +38,13 @@ proton_set_sources_console("${APP}/App.cpp")
 
 #add more sources
 target_sources(RTPack PUBLIC 
-${APP}/main.cpp
-${APP}/FontPacker.cpp
-${APP}/main.cpp
-${APP}/TexturePacker.cpp
+  ${APP}/main.cpp
+  ${APP}/FontPacker.cpp
+  ${APP}/main.cpp
+  ${APP}/TexturePacker.cpp
+  ${PROTON_SHARED}/Renderer/JPGSurfaceLoader.cpp
+)
 
-${PROTON_SHARED}/Renderer/JPGSurfaceLoader.cpp
- 
- )
-
-target_link_libraries(RTPack rt)
+if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  target_link_libraries(RTPack rt)
+endif()

--- a/RTPack/source/TexturePacker.cpp
+++ b/RTPack/source/TexturePacker.cpp
@@ -185,7 +185,7 @@ void EmbedImageFileAsRTTEX(string outputFile, string fileToImbed, SoftSurface &p
 		fwrite(&mipHeader, 1, sizeof(rttex_mip_header), pFileOut);
 
 		//load temp file
-		byte *pBuff = new byte[embedFileSize];
+		uint8 *pBuff = new uint8[embedFileSize];
 
 		FILE *fEmbed = fopen(fileToImbed.c_str(), "rb");
 		if (!fEmbed)
@@ -342,7 +342,7 @@ void WriteTextureWithoutPVR(string pathAndFileName, SoftSurface * texture, int n
 			}
 
 			unsigned int size;
-			byte *pJpgData = LoadFileIntoMemory(tempFilePathAndName, &size);
+			uint8 *pJpgData = LoadFileIntoMemory(tempFilePathAndName, &size);
 			RemoveFile(tempFilePathAndName);
 
 			//write the jpg out

--- a/shared/linux/Proton.cmake
+++ b/shared/linux/Proton.cmake
@@ -339,7 +339,9 @@ function(proton_set_sources)
 		
 	endif(RASPBERRYPI_GLES11)
 
-	target_link_libraries(${PROJECT_NAME} rt)
+	if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+		target_link_libraries(${PROJECT_NAME} rt)
+	endif()
 endfunction(proton_set_sources)
 
 
@@ -361,10 +363,12 @@ function(proton_set_sources_console)
 	endif(NOT PROTON_USE_INTERNAL_ZLIB)
 
 
-if(RASPBERRYPI_GLES11)
-target_link_libraries(${PROJECT_NAME} pthread bcm_host)
-endif(RASPBERRYPI_GLES11)
+	if(RASPBERRYPI_GLES11)
+		target_link_libraries(${PROJECT_NAME} pthread bcm_host)
+	endif(RASPBERRYPI_GLES11)
 
-target_link_libraries(${PROJECT_NAME} rt)
+	if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+		target_link_libraries(${PROJECT_NAME} rt)
+	endif()
 endfunction(proton_set_sources_console)
 


### PR DESCRIPTION
This fixes RTPack compilation for MacOS so it can be compiled without issues again.

<img width="1680" alt="Screenshot 2024-03-18 at 12 01 06" src="https://github.com/SethRobinson/proton/assets/43046474/8283455b-a1ec-438f-b357-9d50b3a7b2df">

on a side note, luckily the XCode projects still works without issues, let me know if this PR has any issues.