### PR TITLE
MiscUtil fixes/tweaks

### DIFF
--- a/shared/util/MiscUtils.cpp
+++ b/shared/util/MiscUtils.cpp
@@ -901,7 +901,7 @@ float StringToFloat( const string &s )
 bool StringToBool(const string& s)
 {
 	string lower = ToLowerCaseString(s);
-	if (lower == "true" || lower == "1"| lower == "yes") return true;
+	if (lower == "true" || lower == "1" || lower == "yes") return true;
 	return false;
 }
 

--- a/shared/util/MiscUtils.h
+++ b/shared/util/MiscUtils.h
@@ -89,6 +89,23 @@ std::string toString(C value)
 	return o.str();
 }
 
+//template overloads for uint8 and int8 as they break for the above function:
+template<>
+inline std::string toString<uint8>(uint8 value)
+{
+	std::ostringstream o{};
+	o << (uint32)value; //cast to uint32 so the stream wont treat it as a character but an actual number.
+	return o.str();
+}
+
+template<>
+inline std::string toString<int8>(int8 value)
+{
+	std::ostringstream o{};
+	o << (int32)value; //again, same as above but make it signed.
+	return o.str();
+}
+
 int StringToInt(const std::string &s);
 float StringToFloat(const std::string &s);
 bool StringToBool(const std::string& s);


### PR DESCRIPTION
- Fix uint8/int8 types for toString being considered as characters and breaking, forcing the user to cast it to an int manually which might get annoying. Will support intended character types as literal characters still as it only creates template overloads for proton's uint8 & int8 typedefs.
- Fix a typo with StringToBool's OR check which will cause undefined behaviour.