### PR TITLE
Use unordered_map on MSVC builds

### DIFF
--- a/shared/Manager/VariantDB.h
+++ b/shared/Manager/VariantDB.h
@@ -40,9 +40,9 @@ public:
 
 #else
 
-#if defined( __APPLE__) || defined(RTLINUX)|| defined(PLATFORM_LINUX)||ANDROID_NDK || defined(PLATFORM_FLASH) || defined(PLATFORM_HTML5) || defined(PLATFORM_PSP2)
+#if defined( __APPLE__) || defined(RTLINUX)|| defined(PLATFORM_LINUX)||ANDROID_NDK || defined(PLATFORM_FLASH) || defined(PLATFORM_HTML5) || defined(PLATFORM_PSP2) || defined(_MSC_VER)
 
-#ifdef PLATFORM_HTML5
+#if defined(PLATFORM_HTML5) || defined(_MSC_VER)
 
 
 	#include <unordered_map>


### PR DESCRIPTION
This fixes an issue in the latest Visual Studio 2026 (May Update) where the "hash_map" include was removed, alongside a number of other deprecated features.

See https://learn.microsoft.com/en-us/visualstudio/releases/2026/release-notes#may-update-1860