### PR TITLE
fix: HTML5 GetSystemTimeTick freeze at ~35 minutes

### DIFF
--- a/shared/html5/HTML5Utils.cpp
+++ b/shared/html5/HTML5Utils.cpp
@@ -226,33 +226,11 @@ int GetYOffset()
 
 unsigned int GetSystemTimeTick()
 {
+	//Use emscripten's API to get high precision system time. This has the same limitation as other platforms GetSystemTimeTick where
+	//this will roll over in 49 days of running. Emscripten's own docs refer it to use Date.now or performance.now as a reference.
 
-	//Note:  Due to using an unsigned int for millseconds, the timer kept rolling over on my linux game server I wrote for
-	//Tanked - so I changed this to start at 0, which gives me 46 days of running before the roll-over.  Why don't I just change
-	//my stuff to handle timing roll-overs or perhaps use a bigger type for timing?  Well.. hmm.  Ok, maybe, but for now this. -Seth
-	
-	static unsigned int incrementingTimer = 0;
-	static double buildUp = 0;
-	static double lastTime = 0;
-
-    
-	/*
-	struct timespec time;
-	clock_gettime(CLOCK_MONOTONIC, &time);
-	double timeDouble = time.tv_sec*1000 + time.tv_nsec/1000000;
-	*/
-
-	//Well, the above doesn't work on the iPhone, it returns 0 only.  So let's use this instead:
-	double timeDouble = clock()/1000;
-
-	double change = timeDouble -lastTime;
-	if (change > 0 && change < (1000*120) )
-	{
-		incrementingTimer += change;
-	}
-	lastTime = timeDouble;
-	
-	return incrementingTimer;
+	static const double startTime = emscripten_get_now();
+	return (unsigned int)(uint64)(emscripten_get_now() - startTime);
 }
 
 uint64 GetSystemTimeTickLong()


### PR DESCRIPTION
Previous approach would freeze the HTML5 application during the fpsTimer waitout while loop in MainEventLoop after about ~35 minutes of runtime. I found this by stepping through wasm when my application froze because of this issue.
I ran this patch for bit over 2 hours now as of writing this and have not encountered the same issue again since.

This approach uses emscripten's API to get precision time, which should be reliable cross-platform. I don't have iOS device to test with on hand to see if the original remark about it applies here, but it shouldn't as emscripten bridges it to Date.now or performance.now in JS.

Changes were tested on Windows PC on Chromium.
Worth checking on weaker devices before merging to see if an alternative resolution is needed for the issue, it could also be worthwhile to see if the commented out approach works on iPhones these days.

Upd: 16 hours runtime without crashes after this change now and continuing to be stable.